### PR TITLE
fix(hive-chart): .Values.image.name should be .Values.image.repository which is standard for charts and allows renovate to automatically detect it

### DIFF
--- a/charts/hive/templates/deployment.yaml
+++ b/charts/hive/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         {{- toYaml .Values.securityContext | trim  | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{.Values.image.name}}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{.Values.image.repository}}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- with .Values.overrideCommand }}
           {{- . | toYaml | nindent 10 }}
           {{- end }}

--- a/charts/hive/templates/statefulset.yaml
+++ b/charts/hive/templates/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
         {{- toYaml .Values.securityContext | trim  | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{.Values.image.name}}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{.Values.image.repository}}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: METASTORE_DB_HOSTNAME

--- a/charts/hive/values.yaml
+++ b/charts/hive/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 ## Default Hive image and tag.
 image:
-  name: harbor.ukserp.ac.uk/dare/hive
+  repository: harbor.ukserp.ac.uk/dare/hive
   tag: 1.1.0
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
BREAKING-CHANGE: This will require deployment values to updated otherwise we'll start silently deploy the default images pinned by the chart instead of the one in the deployment values.